### PR TITLE
Updated Imports

### DIFF
--- a/Helpers/getToken.js
+++ b/Helpers/getToken.js
@@ -1,11 +1,12 @@
 
-import {Platform} from 'react-native';
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
 
 
 const getTokener = {
      // get expo token
     getToken: async ()=>{
-       const token = await Expo.Notifications.getExpoPushTokenAsync();
+       const token = await Notifications.getExpoPushTokenAsync();
        return token;
     },
 

--- a/Helpers/newChannel.js
+++ b/Helpers/newChannel.js
@@ -1,6 +1,7 @@
 
 import {Platform} from 'react-native';
-
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
 
 const newChanneler = {
     // create a new channel
@@ -8,7 +9,7 @@ const newChanneler = {
                   switch(isSound){
                       case false:
                        if (Platform.OS === 'android') {
-                          Expo.Notifications.createChannelAndroidAsync(name, {
+                          Notifications.createChannelAndroidAsync(name, {
                             name: name,
                             sound: false,
                           });
@@ -20,7 +21,7 @@ const newChanneler = {
 
                    case true:
                        if (Platform.OS === 'android') {
-                          Expo.Notifications.createChannelAndroidAsync(name, {
+                          Notifications.createChannelAndroidAsync(name, {
                             name: name,
                             sound: true,
                           });
@@ -32,7 +33,7 @@ const newChanneler = {
 
                        default:
                              if (Platform.OS === 'android') {
-                                Expo.Notifications.createChannelAndroidAsync(name, {
+                                Notifications.createChannelAndroidAsync(name, {
                                   name: name,
                                   sound: false,
                                 });

--- a/Helpers/notifyinit.js
+++ b/Helpers/notifyinit.js
@@ -1,26 +1,27 @@
 
 import {Platform} from 'react-native';
-
+import { Notifications } from 'expo';
+import * as Permissions from 'expo-permissions';
 
 const notifyiniter = {
     // initialize package and ask for notification permission
     initnotify: async ()=>{
-           const {status} = await Expo.Permissions.askAsync(Expo.Permissions.NOTIFICATIONS);
+           const {status} = await Permissions.askAsync(Permissions.NOTIFICATIONS);
            if (status != "granted") {
                  alert('you need to enable notification permission in settings')
                  return false;
            } else {
-               Expo.Notifications.createChannelAndroidAsync('default', {
+               Notifications.createChannelAndroidAsync('default', {
                 name: 'Default',
                 sound: true,
                 });
-                 Expo.Notifications.createChannelAndroidAsync('reminders', {
+                 Notifications.createChannelAndroidAsync('reminders', {
                   name: 'Reminders',
                   priority: 'max',
                   vibrate: [0, 250, 250, 250],
                   sound: true,
                 });
-                 Expo.Notifications.createChannelAndroidAsync('chat-messages', {
+                 Notifications.createChannelAndroidAsync('chat-messages', {
                   name: 'Chat messages',
                   sound: true,
                 });


### PR DESCRIPTION
### **Problem**
_Expo.Permissions.getAsync()_ was returning undefined, because of the modular import changes Expo introduced in order to use their libraries (Permissions).

### **Changes**
Added and updated some lines of the helpers to be able to work with the newer versions of Expo.
- getToken.js
- newChannel.js
- notifyInit.js
